### PR TITLE
Suggest solution for uploading for aws with insufficient permissions

### DIFF
--- a/packages/nodestream-s3/lib/nodestream-s3.es
+++ b/packages/nodestream-s3/lib/nodestream-s3.es
@@ -70,6 +70,8 @@ export default class S3 {
     client.upload(params, s3options, err => {
       if (err) {
         destination.emit('error', err)
+      } else {
+        destination.emit('uploaded')
       }
     })
 

--- a/packages/nodestream/lib/pipeline.es
+++ b/packages/nodestream/lib/pipeline.es
@@ -116,8 +116,9 @@ export default class Pipeline {
         }, file)
 
       file.pipe(destination)
+      destination.once('error', reject)
 
-      destination.once('finish', () => {
+      destination.once(adapter.constructor.name === 'S3' ? 'uploaded' : 'finish', () => {
         for (const transformer of transforms) {
           result[transformer.constructor.identity] = transformer.results()
         }


### PR DESCRIPTION
Regarding issue number [24](https://github.com/nodestream/nodestream/issues/24)  which is related to uploading work inspite of insufficient permissions , 

First adapter upload method is resolved when result stream from createWriteStream emits finished event.

I think problem is that result stream from createWriteStream always emit finished events when it is done even when there is error so I thought of make result stream emit  custom event ( I called 'uploaded') when there is no error in the callback of aws upload method and make adapter upload merhod resolve when emitting this event ( I made this case of aws adapter only)